### PR TITLE
'Create Calendar' option added during Sync step

### DIFF
--- a/app/api/calendar/calendars/route.ts
+++ b/app/api/calendar/calendars/route.ts
@@ -36,3 +36,52 @@ export async function GET(req: NextRequest) {
         );
     }
 }
+
+export async function POST(req: NextRequest) {
+    const accessToken = req.headers.get('authorization')?.replace('Bearer ', '');
+
+    if (!accessToken) {
+        return NextResponse.json({ error: 'Missing access token' }, { status: 401 });
+    }
+
+    try {
+        const body = await req.json();
+        const { summary, description } = body;
+
+        if (!summary) {
+            return NextResponse.json(
+                { error: 'Calendar name (summary) is required' },
+                { status: 400 }
+            );
+        }
+
+        const oauth2Client = new google.auth.OAuth2();
+        oauth2Client.setCredentials({ access_token: accessToken });
+
+        const calendar = google.calendar({ version: 'v3', auth: oauth2Client });
+
+        const response = await calendar.calendars.insert({
+            requestBody: {
+                summary: summary.trim(),
+                description: description?.trim() || undefined,
+                timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            },
+        });
+
+        const newCalendar = {
+            id: response.data.id!,
+            summary: response.data.summary ?? 'Unnamed Calendar',
+            primary: false,
+            backgroundColor: response.data.backgroundColor ?? '#4285f4',
+        };
+
+        return NextResponse.json({ calendar: newCalendar }, { status: 201 });
+    } catch (error: any) {
+        console.error('[calendar/calendars POST] Error creating calendar:', error);
+        const status = error?.code === 401 ? 401 : 500;
+        return NextResponse.json(
+            { error: error?.message ?? 'Failed to create calendar' },
+            { status },
+        );
+    }
+}

--- a/components/figma-app/components/features/CreateCalendarDialog.tsx
+++ b/components/figma-app/components/features/CreateCalendarDialog.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Plus, X, Loader2 } from 'lucide-react';
+
+interface CreateCalendarDialogProps {
+  accessToken: string;
+  onCalendarCreated?: (id: string, summary: string) => void;
+}
+
+export function CreateCalendarDialog({
+  accessToken,
+  onCalendarCreated,
+}: CreateCalendarDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        handleClose();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  function handleClose() {
+    setIsOpen(false);
+    setName('');
+    setDescription('');
+    setError(null);
+  }
+
+  async function handleCreate() {
+    if (!name.trim()) {
+      setError('Calendar name is required');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/calendar/calendars', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          summary: name.trim(),
+          description: description.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? 'Failed to create calendar');
+      }
+
+      onCalendarCreated?.(data.calendar.id, data.calendar.summary);
+      handleClose();
+    } catch (err) {
+      console.error('[CreateCalendarDialog]', err);
+      setError(err instanceof Error ? err.message : 'Failed to create calendar');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleCreate();
+    }
+  }
+
+  return (
+    <>
+      {/* Create button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900"
+        title="Create a new Google Calendar"
+      >
+        <Plus className="h-4 w-4" />
+        <span className="hidden sm:inline">New Calendar</span>
+        <span className="sm:hidden">New</span>
+      </button>
+
+      {/* Modal backdrop and dialog */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 animate-[fadeIn_150ms_ease-out]"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              handleClose();
+            }
+          }}
+        >
+          <div
+            ref={dialogRef}
+            className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white shadow-xl animate-[slideUp_200ms_ease-out]"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+              <h2 className="text-lg font-semibold text-gray-900">Create Calendar</h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="text-gray-400 transition-colors hover:text-gray-600"
+                aria-label="Close dialog"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="space-y-4 px-6 py-4">
+              {/* Calendar name field */}
+              <div>
+                <label
+                  htmlFor="calendar-name"
+                  className="block text-sm font-medium text-gray-700 mb-1.5"
+                >
+                  Calendar Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  ref={inputRef}
+                  id="calendar-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    if (error) setError(null);
+                  }}
+                  onKeyDown={handleKeyDown}
+                  placeholder="e.g., [Course] Schedule"
+                  disabled={isLoading}
+                  className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+                />
+              </div>
+
+              {/* Description field */}
+              <div>
+                <label
+                  htmlFor="calendar-description"
+                  className="block text-sm font-medium text-gray-700 mb-1.5"
+                >
+                  Description (Optional)
+                </label>
+                <textarea
+                  id="calendar-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="e.g., Syllabus events and assignments"
+                  disabled={isLoading}
+                  rows={3}
+                  className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400 resize-none"
+                />
+              </div>
+
+              {/* Error message */}
+              {error && (
+                <div className="rounded-lg bg-rose-50 border border-rose-200 px-3 py-2.5">
+                  <p className="text-xs text-rose-700">{error}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-end gap-2 border-t border-gray-100 px-6 py-4">
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={isLoading}
+                className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-200 rounded-lg transition-colors hover:bg-gray-50 disabled:text-gray-400 disabled:hover:bg-transparent"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={isLoading || !name.trim()}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg transition-colors hover:bg-indigo-700 disabled:bg-indigo-400 disabled:cursor-not-allowed"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Creating…
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4" />
+                    Create
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/figma-app/components/features/Uploads.tsx
+++ b/components/figma-app/components/features/Uploads.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import PdfUpload from '@/components/PdfUpload';
 import { Checkbox } from '@/components/ui/checkbox';
+import { CreateCalendarDialog } from './CreateCalendarDialog';
 import type { CalendarEvent } from '@/lib/googleCalendar';
 
 /** Sample events so users can open Review/Sync without uploading first (e.g. after "New upload"). Same titles as the original Calendar mock events on main. */
@@ -141,11 +142,13 @@ function CalendarPicker({
   selectedCalendarId,
   selectedCalendarSummary,
   onSelect,
+  refetchTrigger,
 }: {
   accessToken: string;
   selectedCalendarId: string;
   selectedCalendarSummary: string,
   onSelect: (id: string, summary: string) => void;
+  refetchTrigger?: number;
 }) {
   const [open, setOpen] = useState(false);
   const [calendars, setCalendars] = useState<GoogleCalendarMeta[]>([]);
@@ -164,7 +167,7 @@ function CalendarPicker({
   }, [open]);
 
   async function fetchCalendars() {
-    if (fetchStatus === 'ok' || fetchStatus === 'loading') return;
+    if (fetchStatus === 'loading') return;
     setFetchStatus('loading');
     try {
       const res = await fetch('/api/calendar/calendars', {
@@ -180,8 +183,16 @@ function CalendarPicker({
     }
   }
 
+  // Refetch when refetchTrigger changes
+  useEffect(() => {
+    fetchCalendars();
+  }, [refetchTrigger]);
+
   function handleToggle() {
-    if (!open) fetchCalendars();
+    if (!open) {
+      setFetchStatus('idle');
+      fetchCalendars();
+    }
     setOpen((o) => !o);
   }
 
@@ -344,6 +355,7 @@ export function Uploads({ initialAccessToken, onAccessTokenChange }: UploadsProp
     } catch { /* ignore */ }
     return 'Default calendar';
   });
+  const [calendarRefetchTrigger, setCalendarRefetchTrigger] = useState(0);
 
   const accessToken = initialAccessToken;
   const hasEvents = events.length > 0;
@@ -1035,30 +1047,44 @@ export function Uploads({ initialAccessToken, onAccessTokenChange }: UploadsProp
                     <p className="text-sm font-semibold text-gray-900">Calendar</p>
                     <p className="text-xs text-gray-500">
                       {isGoogleConnected
-                        ? 'Choose which calendar to sync events into.'
-                        : 'Connect Google to choose a calendar.'}
+                        ? 'Create or choose which calendar to sync events into.'
+                        : 'Connect Google to create or choose a calendar.'}
                     </p>
                   </div>
 
                   {isGoogleConnected ? (
-                    <CalendarPicker
-                      accessToken={accessToken!}
-                      selectedCalendarId={selectedCalendarId}
-                      selectedCalendarSummary={selectedCalendarSummary}
-                      onSelect={(id, summary) => {
-                        setSelectedCalendarId(id);
-                        setSelectedCalendarSummary(summary);
-                        try {
-                          localStorage.setItem(CALENDAR_PREF_KEY, JSON.stringify({ id, summary }));
-                        } catch { /* ignore */ }
-                        if (hasSynced) {
-                          setHasSynced(false);
-                          setSyncBurst(false);
-                          setCalendarStatus('idle');
-                          setCalendarMessage('');
-                        }
-                      }}
-                    />
+                    <div className="inline-flex items-center gap-2">
+                      <CalendarPicker
+                        accessToken={accessToken!}
+                        selectedCalendarId={selectedCalendarId}
+                        selectedCalendarSummary={selectedCalendarSummary}
+                        refetchTrigger={calendarRefetchTrigger}
+                        onSelect={(id, summary) => {
+                          setSelectedCalendarId(id);
+                          setSelectedCalendarSummary(summary);
+                          try {
+                            localStorage.setItem(CALENDAR_PREF_KEY, JSON.stringify({ id, summary }));
+                          } catch { /* ignore */ }
+                          if (hasSynced) {
+                            setHasSynced(false);
+                            setSyncBurst(false);
+                            setCalendarStatus('idle');
+                            setCalendarMessage('');
+                          }
+                        }}
+                      />
+                      <CreateCalendarDialog
+                        accessToken={accessToken!}
+                        onCalendarCreated={(id, summary) => {
+                          setCalendarRefetchTrigger((t) => t + 1);
+                          setSelectedCalendarId(id);
+                          setSelectedCalendarSummary(summary);
+                          try {
+                            localStorage.setItem(CALENDAR_PREF_KEY, JSON.stringify({ id, summary }));
+                          } catch { /* ignore */ }
+                        }}
+                      />
+                    </div>
                   ) : (
                     <span className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-400">
                       <span className="h-2.5 w-2.5 rounded-full bg-gray-300" />


### PR DESCRIPTION
## Description
In this PR, I added an option for users to create a calendar 'category' in their Google Calendar account. Allows users to separate course schedules or organize their personal vs work/school calendars from within the web app.

Issue Link: #195 

## Testing
1. Install dependencies `npm i`
2. Start the program on localhost: `npm run dev`
3. Navigate through the login, upload and review steps
4. Once you reach the sync step, make sure there exists a `New Calendar` button and the dropdown Calendar selector
5. Connect your Google account
6. Create a new 'test' calendar and sync events
7. Ensure the events appear in the created test calendar

## Attachments
### Both buttons appear once connected
<img width="1926" height="840" alt="image" src="https://github.com/user-attachments/assets/33f18619-e1de-4dc5-9bce-3794d7b858f2" />

### Create calendar pop up
<img width="1988" height="878" alt="image" src="https://github.com/user-attachments/assets/cb7f1a97-578b-4f52-9e42-5db38d7f42a8" />

### After creating new calendar, immediately appears in dropdown list
<img width="1940" height="844" alt="image" src="https://github.com/user-attachments/assets/252c80a8-ae36-42af-9647-dc511c09755c" />

## Notes
- Didn't write integration tests, but if needed I can also add those!

## Acceptance Criteria
```
Scenario 1: User adds category
Given the user clicks on the calendar category button and presses to add a category
When they press confirm
Then a new Google Calendar category will be added to their Google Calendar
And this category is visible on the category button as an option
```

Closes #195 