### PR TITLE
added edit events to review section

### DIFF
--- a/components/figma-app/components/features/Uploads.tsx
+++ b/components/figma-app/components/features/Uploads.tsx
@@ -10,6 +10,7 @@ import {
   User,
   ChevronDown,
   Check,
+  Pencil,
 } from 'lucide-react';
 import PdfUpload from '@/components/PdfUpload';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -32,6 +33,51 @@ function getSampleEvents(): CalendarEvent[] {
     { title: 'CS 101 Lecture', start: dStr(24) + 'T10:00:00', allDay: false },
     { title: 'Lab Report Due', start: dStr(30), allDay: true },
   ];
+}
+
+const WEEKLY_REPEAT_DAY_LABELS = ['Sun', 'M', 'Tue', 'W', 'Th', 'F', 'Sat'] as const;
+const RRULE_DAY_MAP = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'] as const;
+
+function getTimeFromISO(iso: string): string {
+  if (!iso.includes('T')) return '09:00';
+  const d = new Date(iso);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function buildRecurrence(
+  repeat: 'none' | 'daily' | 'weekdays' | 'weekly',
+  weeklyDays: boolean[],
+  endType: 'never' | 'date' | 'count',
+  endDate: string,
+  endCount: number
+): string[] {
+  if (repeat === 'none') return [];
+  const parts: string[] = [];
+  if (repeat === 'daily') parts.push('FREQ=DAILY');
+  else if (repeat === 'weekdays') parts.push('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR');
+  else if (repeat === 'weekly') {
+    const days = weeklyDays.map((on, i) => (on ? RRULE_DAY_MAP[i] : null)).filter(Boolean);
+    if (days.length === 0) return [];
+    parts.push('FREQ=WEEKLY;BYDAY=' + (days as string[]).join(','));
+  } else return [];
+  if (endType === 'date' && endDate) {
+    const d = new Date(endDate + 'T23:59:59');
+    parts.push('UNTIL=' + d.toISOString().replace(/[-:]/g, '').slice(0, 15) + 'Z');
+  } else if (endType === 'count' && endCount > 0) {
+    parts.push('COUNT=' + endCount);
+  }
+  return ['RRULE:' + parts.join(';')];
+}
+
+function parseRecurrenceToRepeat(rrules: string[] | undefined): 'none' | 'daily' | 'weekdays' | 'weekly' {
+  if (!rrules || rrules.length === 0) return 'none';
+  const r = rrules[0].replace(/^RRULE:/i, '');
+  if (r.includes('FREQ=DAILY')) return 'daily';
+  if (r.includes('BYDAY=MO,TU,WE,TH,FR') && !r.includes('SA') && !r.includes('SU')) return 'weekdays';
+  if (r.includes('FREQ=WEEKLY')) return 'weekly';
+  return 'none';
 }
 
 interface UploadsProps {
@@ -685,6 +731,76 @@ export function Uploads({ initialAccessToken, onAccessTokenChange }: UploadsProp
   const isSyncComplete = hasSynced && calendarStatus === 'ok';
 
   const [showRegenerateModal, setShowRegenerateModal] = useState(false);
+
+  const [reviewEditEvent, setReviewEditEvent] = useState<CalendarEvent | null>(null);
+  const [revTitle, setRevTitle] = useState('');
+  const [revDate, setRevDate] = useState('');
+  const [revAllDay, setRevAllDay] = useState(true);
+  const [revStartTime, setRevStartTime] = useState('09:00');
+  const [revEndTime, setRevEndTime] = useState('10:00');
+  const [revDescription, setRevDescription] = useState('');
+  const [revRepeat, setRevRepeat] = useState<'none' | 'daily' | 'weekdays' | 'weekly'>('none');
+  const [revWeeklyDays, setRevWeeklyDays] = useState([false, false, true, true, true, true, false]);
+  const [revEndType, setRevEndType] = useState<'never' | 'date' | 'count'>('never');
+  const [revEndDate, setRevEndDate] = useState('');
+  const [revEndCount, setRevEndCount] = useState(5);
+  const [reviewDeleteConfirm, setReviewDeleteConfirm] = useState(false);
+
+  function openReviewEdit(e: CalendarEvent) {
+    setReviewEditEvent(e);
+    setRevTitle(e.title);
+    const d = e.start.includes('T') ? e.start.slice(0, 10) : e.start.slice(0, 10);
+    setRevDate(d);
+    setRevAllDay(!!e.allDay);
+    setRevStartTime(getTimeFromISO(e.start));
+    setRevEndTime(getTimeFromISO(e.end ?? e.start));
+    setRevDescription(e.description ?? '');
+    setRevRepeat(parseRecurrenceToRepeat(e.recurrence));
+    setRevWeeklyDays([false, false, true, true, true, true, false]);
+    setRevEndType('never');
+    setRevEndDate('');
+    setRevEndCount(5);
+    setReviewDeleteConfirm(false);
+  }
+
+  function closeReviewEdit() {
+    setReviewEditEvent(null);
+    setReviewDeleteConfirm(false);
+  }
+
+  function handleReviewEditSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!reviewEditEvent || !revTitle.trim()) return;
+    const start = revAllDay ? revDate + 'T00:00:00' : revDate + 'T' + revStartTime + ':00';
+    const end = revAllDay ? revDate + 'T00:00:00' : revDate + 'T' + revEndTime + ':00';
+    const recurrence = buildRecurrence(revRepeat, revWeeklyDays, revEndType, revEndDate, revEndCount);
+    const updated: CalendarEvent = {
+      ...reviewEditEvent,
+      title: revTitle.trim(),
+      start,
+      end: revAllDay ? undefined : end,
+      allDay: revAllDay,
+      description: revDescription.trim() || undefined,
+      recurrence: recurrence.length ? recurrence : undefined,
+    };
+    const nextEvents = events.map((ev) => (ev === reviewEditEvent ? updated : ev));
+    setEvents(nextEvents);
+    try {
+      localStorage.setItem('calendarEvents', JSON.stringify(nextEvents));
+    } catch { /* ignore */ }
+    closeReviewEdit();
+  }
+
+  function handleReviewEditDelete() {
+    if (!reviewEditEvent) return;
+    const next = events.filter((ev) => ev !== reviewEditEvent);
+    setEvents(next);
+    try {
+      localStorage.setItem('calendarEvents', JSON.stringify(next));
+    } catch { /* ignore */ }
+    closeReviewEdit();
+  }
+
   return (
     <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(1200px_circle_at_20%_5%,theme(colors.indigo.100),transparent_55%),radial-gradient(1000px_circle_at_80%_35%,theme(colors.violet.100),transparent_60%),linear-gradient(to_bottom,theme(colors.white),theme(colors.slate.50))] transition-all duration-700" />
@@ -872,23 +988,34 @@ export function Uploads({ initialAccessToken, onAccessTokenChange }: UploadsProp
                 {filteredEvents.slice(0, 50).map((e, idx) => (
                   <div
                     key={idx}
-                    className="flex items-start justify-between border-b border-gray-100 last:border-0 py-2"
+                    className="flex items-start justify-between border-b border-gray-100 last:border-0 py-2 gap-2"
                   >
-                    <div className="pr-4">
-                      <p className="font-medium text-gray-900 line-clamp-2">{e.title}</p>
-                      {e.description && (
-                        <span className={
-                          'mt-1 inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ' +
-                          (e.description === 'LECTURE' ? 'bg-blue-50 text-blue-600' :
-                          e.description === 'ASSIGNMENT' ? 'bg-amber-50 text-amber-600' :
-                          e.description === 'EXAM' ? 'bg-rose-50 text-rose-600' :
-                          'bg-gray-100 text-gray-500')
-                        }>
-                          {e.description}
-                        </span>
-                      )}
+                    <div className="flex items-start gap-2 min-w-0 flex-1">
+                      <button
+                        type="button"
+                        onClick={() => openReviewEdit(e)}
+                        className="flex-shrink-0 p-1.5 rounded-lg border border-gray-200 text-gray-500 hover:bg-indigo-50 hover:text-indigo-700 hover:border-indigo-200 transition-colors"
+                        title="Edit event"
+                        aria-label="Edit event"
+                      >
+                        <Pencil className="w-3.5 h-3.5" />
+                      </button>
+                      <div className="pr-4 min-w-0">
+                        <p className="font-medium text-gray-900 line-clamp-2">{e.title}</p>
+                        {e.description && (
+                          <span className={
+                            'mt-1 inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ' +
+                            (e.description === 'LECTURE' ? 'bg-blue-50 text-blue-600' :
+                            e.description === 'ASSIGNMENT' ? 'bg-amber-50 text-amber-600' :
+                            e.description === 'EXAM' ? 'bg-rose-50 text-rose-600' :
+                            'bg-gray-100 text-gray-500')
+                          }>
+                            {e.description}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                    <div className="text-right text-xs text-gray-500 whitespace-nowrap">
+                    <div className="text-right text-xs text-gray-500 whitespace-nowrap flex-shrink-0">
                       <p>{new Date(e.start).toLocaleString()}</p>
                       <p>{e.allDay ? 'All day' : 'Timed'}</p>
                     </div>
@@ -1165,6 +1292,201 @@ export function Uploads({ initialAccessToken, onAccessTokenChange }: UploadsProp
                 New Upload
               </button>
             </div>
+          </div>
+        </div>
+      )}
+
+      {reviewEditEvent && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="review-edit-event-title"
+        >
+          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
+            <h2 id="review-edit-event-title" className="text-lg font-semibold text-gray-900 mb-4">
+              Edit event
+            </h2>
+            {reviewDeleteConfirm ? (
+              <div className="space-y-4">
+                <p className="text-sm text-gray-700">
+                  Remove this event from the list? It will not be synced to Google Calendar.
+                </p>
+                <div className="flex gap-2 justify-end">
+                  <button
+                    type="button"
+                    onClick={() => setReviewDeleteConfirm(false)}
+                    className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleReviewEditDelete}
+                    className="px-4 py-2 rounded-lg bg-red-600 text-white font-medium hover:bg-red-700"
+                  >
+                    Confirm
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <form onSubmit={handleReviewEditSave} className="space-y-4">
+                <div>
+                  <label htmlFor="rev-title" className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+                  <input
+                    id="rev-title"
+                    type="text"
+                    value={revTitle}
+                    onChange={(e) => setRevTitle(e.target.value)}
+                    required
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    placeholder="Event title"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="rev-date" className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+                  <input
+                    id="rev-date"
+                    type="date"
+                    value={revDate}
+                    onChange={(e) => setRevDate(e.target.value)}
+                    required
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="rev-allday"
+                    type="checkbox"
+                    checked={revAllDay}
+                    onChange={(e) => setRevAllDay(e.target.checked)}
+                    className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <label htmlFor="rev-allday" className="text-sm text-gray-700">All day</label>
+                </div>
+                {!revAllDay && (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label htmlFor="rev-start-time" className="block text-sm font-medium text-gray-700 mb-1">Start time</label>
+                      <input
+                        id="rev-start-time"
+                        type="time"
+                        value={revStartTime}
+                        onChange={(e) => setRevStartTime(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="rev-end-time" className="block text-sm font-medium text-gray-700 mb-1">End time</label>
+                      <input
+                        id="rev-end-time"
+                        type="time"
+                        value={revEndTime}
+                        onChange={(e) => setRevEndTime(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      />
+                    </div>
+                  </div>
+                )}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Repeat</label>
+                  <select
+                    value={revRepeat}
+                    onChange={(e) => setRevRepeat(e.target.value as 'none' | 'daily' | 'weekdays' | 'weekly')}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  >
+                    <option value="none">Does not repeat</option>
+                    <option value="daily">Daily</option>
+                    <option value="weekdays">Weekdays (M–F)</option>
+                    <option value="weekly">Weekly — pick which days below</option>
+                  </select>
+                  {revRepeat === 'weekly' && (
+                    <div className="mt-2">
+                      <p className="text-xs text-gray-600 mb-1.5">Repeat on these days:</p>
+                      <div className="grid grid-cols-7 gap-1">
+                        {WEEKLY_REPEAT_DAY_LABELS.map((label, i) => (
+                          <label key={label} className="inline-flex items-center justify-center gap-1 px-1 py-1 rounded border border-gray-300 bg-white text-gray-900 text-xs cursor-pointer hover:bg-gray-50 has-[:checked]:border-indigo-500 has-[:checked]:bg-indigo-100">
+                            <input
+                              type="checkbox"
+                              checked={revWeeklyDays[i]}
+                              onChange={(e) => {
+                                const next = [...revWeeklyDays];
+                                next[i] = e.target.checked;
+                                setRevWeeklyDays(next);
+                              }}
+                              className="rounded border-gray-300 text-indigo-600"
+                            />
+                            <span className="font-medium shrink-0">{label}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {(revRepeat === 'daily' || revRepeat === 'weekdays' || revRepeat === 'weekly') && (
+                    <div className="mt-2 space-y-2">
+                      <label className="block text-xs text-gray-600">Ends</label>
+                      <select
+                        value={revEndType}
+                        onChange={(e) => setRevEndType(e.target.value as 'never' | 'date' | 'count')}
+                        className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg"
+                      >
+                        <option value="never">Never</option>
+                        <option value="date">On a specific date</option>
+                        <option value="count">After a number of occurrences</option>
+                      </select>
+                      {revEndType === 'date' && (
+                        <input
+                          type="date"
+                          value={revEndDate}
+                          onChange={(e) => setRevEndDate(e.target.value)}
+                          className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg"
+                        />
+                      )}
+                      {revEndType === 'count' && (
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="number"
+                            min={1}
+                            value={revEndCount}
+                            onChange={(e) => setRevEndCount(parseInt(e.target.value, 10) || 5)}
+                            className="w-20 px-3 py-1.5 text-sm border border-gray-300 rounded-lg"
+                          />
+                          <span className="text-sm text-gray-600">occurrences</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <label htmlFor="rev-desc" className="block text-sm font-medium text-gray-700 mb-1">Description (optional)</label>
+                  <textarea
+                    id="rev-desc"
+                    value={revDescription}
+                    onChange={(e) => setRevDescription(e.target.value)}
+                    rows={2}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    placeholder="Description"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-2 justify-between pt-2">
+                  <button
+                    type="button"
+                    onClick={() => setReviewDeleteConfirm(true)}
+                    className="px-3 py-2 rounded-lg text-sm text-red-600 hover:bg-red-50 border border-red-200"
+                  >
+                    Delete event
+                  </button>
+                  <div className="flex gap-2">
+                    <button type="button" onClick={closeReviewEdit} className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50">
+                      Cancel
+                    </button>
+                    <button type="submit" className="px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">
+                      Save
+                    </button>
+                  </div>
+                </div>
+              </form>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #174 
## Description
Adds per-event edit (pencil icon) on the Review step so users can fix mistakes before syncing. Clicking the pencil opens the same-style event form as the Calendar (title, date, all-day, time, repeat, description). Users can save changes or delete the event; the review list and raw CSV both update from the same events state.

## Testing
1. Go to Uploads and reach the Review step (upload/process a syllabus or use “Review Previous” if events exist).
2. On the Review page, confirm each event row has a pencil icon to the left of the title/date.
3. Edit: Click the pencil on an event → modal opens with “Edit event” and that event’s details. Change the event name (or date/time/description). Click Save → modal closes, the row shows the new details, and the “Show raw CSV” section below shows the updated line for that event.
4. Delete: Click the pencil on another event → modal opens. Click Delete event → confirm message appears. Click Confirm → modal closes, that event is gone from the list, and the raw CSV no longer contains that line.
5. Confirm the list and raw CSV stay in sync after several edits and deletes.

<img width="969" height="435" alt="image" src="https://github.com/user-attachments/assets/402694df-05d4-4fc8-96ce-1fdb502f1ae2" />

