### PR TITLE
getCalendarAccessToken() called in POST request handling

### DIFF
--- a/app/api/calendar/calendars/route.ts
+++ b/app/api/calendar/calendars/route.ts
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-    const accessToken = req.headers.get('authorization')?.replace('Bearer ', '');
+    const accessToken = getCalendarAccessToken(req)
 
     if (!accessToken) {
         return NextResponse.json({ error: 'Missing access token' }, { status: 401 });


### PR DESCRIPTION
## Description
Fixed the create calendar access token bug by accessing getCalendarAccessToken() in the post request

Issue Link: https://github.com/ucsb-cs148-w26/pj10-syllabus-to-cal-3pm/issues/233#issue-4043405104

## Testing
1. npm run dev
2. upload syllabi
3. process
4. go to export/sync
5. try to create calendar
6. confirm calendar creation was successful