### PR TITLE
#194 - Fixed CSV upload bug, fixed missing calendar end-time

### DIFF
--- a/app/api/gemini/route.ts
+++ b/app/api/gemini/route.ts
@@ -133,7 +133,7 @@ RULE C — ADDING ONE-TIME EVENTS: If the instruction mentions a specific date a
   - Set description to LECTURE.
   - Leave class empty unless the user specifies a course.
   - Example: user says "I have a meeting at 2026/03/06 at 7:00 pm"
-    → Meeting,2026-03-06T19:00:00,false,LECTURE,,,2026-03-06T20:00:00
+    → Meeting,2026-03-06T19:00:00,false,LECTURE,,
 
 Output ONLY valid CSV rows in the established format. No markdown, no explanations.
 `
@@ -147,7 +147,7 @@ No markdown. No explanations.
 Only include: ${eventTypesStr}
 
 RULES:
-- Ignore holidays, office hours, breaks, readings, or optional items.
+- Ignore holidays, office hours, breaks, assignments release dates, or optional items. 
 
 OUTPUT FORMAT (STRICT):
 Output EXACTLY 7 columns in this EXACT order:
@@ -170,11 +170,12 @@ start:
 
 allDay:
 - true or false (lowercase)
-- LECTURE and EXAM events with a known time → false
-- ASSIGNMENT events → always true
 
 description:
-- Use event type (LECTURE / ASSIGNMENT / EXAM)
+- Start with the event type keyword: LECTURE, ASSIGNMENT, or EXAM
+- If there are readings or important notes associated with this event (e.g. "Read Ch. 8", "HW 3 due", "bring calculator"), append them after a pipe separator: LECTURE | Ch. 8 Reading Due
+- Keep notes brief (under 10 words). No commas. Only include notes explicitly tied to this specific event.
+- If no notes, use just the keyword: LECTURE
 
 location:
 - Specify Location if mentioned in the files, else ALWAYS leave empty
@@ -194,8 +195,8 @@ end:
 EXAMPLE:
 
 title,start,allDay,description,location,class,end
-Lecture,2025-03-31T08:00:00,false,LECTURE,,WRIT 105CW,2025-03-31T09:15:00
-Midterm Exam,2025-04-15T10:00:00,false,EXAM,,WRIT 105CW,2025-04-15T12:00:00
+Lecture,2025-03-31T08:00:00,false,LECTURE | Ch. 8 Reading Due,,WRIT 105CW,2025-03-31T09:15:00
+Midterm Exam,2025-04-15T10:00:00,false,EXAM | bring blue book,,WRIT 105CW,2025-04-15T12:00:00
 Service Pledge Due,2025-04-23,true,ASSIGNMENT,,WRIT 105CW,
 
 ${userInstructionsSection}

--- a/components/figma-app/components/features/Uploads.tsx
+++ b/components/figma-app/components/features/Uploads.tsx
@@ -1433,7 +1433,7 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
                         </>
                       ) : (
                         <>
-                          <p>{new Date(e.start).toLocaleString()}{e.end ? ` – ${new Date(e.end).toLocaleTimeString()}` : ''}</p>
+                          <p>{new Date(e.start).toLocaleString()}{e.end && e.end !== e.start ? ` – ${new Date(e.end).toLocaleTimeString()}` : ''}</p>
                           <p className="whitespace-nowrap">Timed</p>
                         </>
                       )}
@@ -1500,11 +1500,11 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
                 <p className="text-gray-500">No events to display. Upload a syllabus first.</p>
               ) : (
                 <pre className="whitespace-pre-wrap break-words text-xs">
-                  title,start,allDay,description,location,class{"\n"}
+                  title,start,allDay,description,location,class,end{"\n"}
                   {events
                     .map(
                       (e) =>
-                        `${e.title},${e.start},${String(e.allDay)},${e.description ?? ''},${e.location ?? ''},${e.class ?? ''}`,
+                        `${e.title},${e.start},${String(e.allDay)},${e.description ?? ''},${e.location ?? ''},${e.class ?? ''},${e.end ?? ''}`,
                     )
                     .join('\n')}
                 </pre>

--- a/lib/csvEvents.ts
+++ b/lib/csvEvents.ts
@@ -127,15 +127,24 @@ export function parseCsvToCalendarEvents(csvText: string): CalendarEvent[] {
 
     if (!title && !start) continue;
 
-    const type = rawDescription === 'EXAM' ? 'exam' : rawDescription === 'ASSIGNMENT' ? 'assignment' : rawDescription === 'LECTURE' ? 'class' : undefined;
-    const typeLabel = rawDescription === 'EXAM' ? 'Exam' : rawDescription === 'ASSIGNMENT' ? 'Assignment' : rawDescription === 'LECTURE' ? 'Lecture' : rawDescription;
-    const description = course ? `${course} – ${typeLabel}` : typeLabel;
+    const [typeKeyword, ...notesParts] = rawDescription.split('|');
+    const typeKey = typeKeyword.trim();
+    const notes = notesParts.join('|').trim();
+    const type = typeKey === 'EXAM' ? 'exam' : typeKey === 'ASSIGNMENT' ? 'assignment' : typeKey === 'LECTURE' ? 'class' : undefined;
+    const typeLabel = typeKey === 'EXAM' ? 'Exam' : typeKey === 'ASSIGNMENT' ? 'Assignment' : typeKey === 'LECTURE' ? 'Lecture' : typeKey;
+    const baseDescription = course ? `${course} – ${typeLabel}` : typeLabel;
+    const description = notes ? `${baseDescription}\n${notes}` : baseDescription;
+
+    // Assignments are zero-duration timed events (start == end), never all-day
+    const isAssignment = type === 'assignment';
+    const allDay = isAssignment ? false : ['true', '1', 'yes', 'y'].includes(allDayRaw);
+    const resolvedEnd = end || (isAssignment ? start : undefined);
 
     events.push({
       title,
       start,
-      end: end || undefined,
-      allDay: ['true', '1', 'yes', 'y'].includes(allDayRaw),
+      end: resolvedEnd || undefined,
+      allDay,
       description,
       location,
       class: course,


### PR DESCRIPTION
## Description
- Fixed CSV headers in manual download to allow successful import
- Fixed events from not showing event end time

Issue Link: https://github.com/orgs/ucsb-cs148-w26/projects/24/views/1?pane=issue&itemId=160635224&issue=ucsb-cs148-w26%7Cpj10-syllabus-to-cal-3pm%7C194

## Testing
1. upload a syllabus
2. process
3. manually download csv
4. open google calendar
5. go to settings
6. go to import
7. import csv file to calendar and confirm all events uploaded
8. return to website
9. go to export
10. export to google calendar
11. confirm events successfully imported with end time (you should see duplicate events)   

## Attachments

## Notes

## Acceptance Criteria
```gherkin
Scenario 1: User downloads CSV
Given the user has downloaded a CSV
When they import it to Google Calendar
Then all valid events will be added to Google Calendar
```