### PR TITLE
Added an extra rule to gemini

### DIFF
--- a/app/api/gemini/route.ts
+++ b/app/api/gemini/route.ts
@@ -164,9 +164,21 @@ title:
 - Do NOT include course name
 - Do NOT include commas
 
+
 start:
 - If allDay=false → YYYY-MM-DDTHH:MM:SS
 - If allDay=true → YYYY-MM-DD
+
+UNKNOWN DATE RULE:
+
+If an event exists but the syllabus does not specify a date
+(e.g. "3 quizzes during the semester", "final exam TBD"):
+
+- DO NOT discard the event.
+- Generate one row per event.
+- Set start=UNKNOWN
+- Set allDay=true
+- Leave end empty.
 
 allDay:
 - true or false (lowercase)


### PR DESCRIPTION
Closes #239 - Added an extra rule to gemini to handle events with unknown dates

Added the following prompt: 
```
UNKNOWN DATE RULE:

If an event exists but the syllabus does not specify a date
(e.g. "3 quizzes during the semester", "final exam TBD"):

- DO NOT discard the event.
- Generate one row per event.
- Set start=UNKNOWN
- Set allDay=true
- Leave end empty.
```

To test
Add/Create syllabus with unspecified dates


Acceptance Criteria:
```
## Acceptance Criteria

### Scenario 1: Event exists but no explicit date is provided
Given a syllabus transcript contains an event (lecture, assignment, or exam) but no specific date is provided  
When the system processes the syllabus using the LLM extraction pipeline  
Then the event should still be included in the output CSV  
And the event should be marked as allDay=true  
And the start column should contain the value UNKNOWN  
And the end column should be empty

---

### Scenario 2: Multiple unspecified events are described
Given a syllabus transcript states that multiple events occur during the semester without specific dates (e.g., "There will be 3 quizzes during the semester")  
When the system extracts events from the syllabus  
Then the system should generate one row per event  
And each event should appear in the output CSV  
And each event should have start=UNKNOWN  
And each event should have allDay=true

---

### Scenario 3: Events with valid dates remain unchanged
Given a syllabus transcript contains events with valid dates and times  
When the system processes the syllabus  
Then those events should use the extracted date and time in ISO format  
And the system should not replace the date with UNKNOWN

---

### Scenario 4: Events without time but with valid date
Given a syllabus transcript specifies an event date but no time  
When the system extracts the event  
Then the event should be marked as allDay=true  
And the start column should contain the valid date in YYYY-MM-DD format  
And the end column should be empty

---

### Scenario 5: CSV format consistency
Given the system generates calendar events  
When the CSV output is produced  
Then the output must always contain the header  
title,start,allDay,description,location,class,end  
And each row must contain exactly 7 columns
```
