### PR TITLE
Updated OTHER category filter visibility

### DIFF
--- a/components/figma-app/components/features/Uploads.tsx
+++ b/components/figma-app/components/features/Uploads.tsx
@@ -1045,6 +1045,7 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
             if (categoryFilter === 'LECTURE') return e.type === 'class';
             if (categoryFilter === 'ASSIGNMENT') return e.type === 'assignment';
             if (categoryFilter === 'EXAM') return e.type === 'exam';
+            if (categoryFilter === 'OTHER') return e.type === undefined;
             return false;
           }),
       [events, categoryFilter],
@@ -1338,12 +1339,14 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
                     { key: 'LECTURE', label: 'Lectures' },
                     { key: 'ASSIGNMENT', label: 'Assignments' },
                     { key: 'EXAM', label: 'Exams' },
+                    { key: 'OTHER', label: 'Other' },
                   ] as { key: CategoryFilter; label: string }[]
                 ).map(({ key, label }) => {
                   const count = key === 'ALL' ? events.length : events.filter((e) =>
                     key === 'LECTURE' ? e.type === 'class' :
                     key === 'ASSIGNMENT' ? e.type === 'assignment' :
-                    key === 'EXAM' ? e.type === 'exam' : false
+                    key === 'EXAM' ? e.type === 'exam' :
+                    key === 'OTHER' ? e.type === undefined : false
                   ).length;
                   return (
                     <button
@@ -1433,6 +1436,7 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
                               (label === 'LECTURE' ? 'bg-blue-50 text-blue-600' :
                               label === 'ASSIGNMENT' ? 'bg-amber-50 text-amber-600' :
                               label === 'EXAM' ? 'bg-rose-50 text-rose-600' :
+                              label === 'OTHER' ? 'bg-gray-50 text-gray-600' :
                               'bg-gray-100 text-gray-500')
                             }
                           >{label}</button>
@@ -1823,7 +1827,7 @@ export function Uploads({ initialAccessToken, onAccessTokenChange, isAuthenticat
                     <span className="inline-flex items-center gap-2">
                       {plannerUploadStatus === 'done' ? (
                         <>
-                        
+
                         <BookOpen className="h-4 w-4 animate-pulse" />
                         Exported
                         </>


### PR DESCRIPTION
## Description
Added the `OTHER` category to the header during Review Step to be visible. If events were not defined, or users want to separate specific events to have no category, allows them to view those separately instead of looking through the `ALL` filter list.

Issue Link: N/A

## Testing
1. `npm run dev`
2. Upload syllabus
3. Edit/Create event and change label to `OTHER` (by clicking on the label of the event until it switches to `OTHER`
4. Click on filter and see event under `OTHER` filter list

## Attachments
### Review Step - Event has `OTHER` label in `All` filter list
<img width="1061" height="678" alt="image" src="https://github.com/user-attachments/assets/6594920d-7a8b-4e17-ac12-1bf102ca4a0e" />

### Review Step - Event appears under `OTHER` filter list
<img width="1070" height="319" alt="image" src="https://github.com/user-attachments/assets/cfdd080b-05a7-46f0-ace7-954a71e69501" />

## Acceptance Criteria
```
Scenario 1: Created new event has default label to `OTHER`
Given uploaded syllabus has been processed and user has continued to the `Review` step
When user clicks `Add event` button to create a new event
Then the new event should have a default label set to `OTHER`
And clicking the label can switch to another label
And event falls under the correct filter list immediately depending on which label is selected

Scenario 2: Edited event can switch to `OTHER` label
Given uploaded syllabus extracts valid events and user is in `Review` step
When user clicks on label of existing event to edit, and switch it to `OTHER`
Then the label switches to the desired label
And the event appears under the `OTHER` filter list
```